### PR TITLE
Documentation warning update

### DIFF
--- a/docs/features/events.md
+++ b/docs/features/events.md
@@ -30,5 +30,5 @@ nav_order: 4
 ## Creating an Event
 
 - Go to Settings -> Events and press "+ Add"
-- To run scripts, use a "system" trigger and follow the [commands](/features/commands/) instructions.
+- To run scripts, use a "system" trigger and follow the [commands](/features/commands/) instructions. The event scripts reside in the events folder under the base makerverse folder and regardless of the makerverse folder name, the path to get to the event is ~/makerverse/events/scriptname.
 - To run Gcode, use a "G-code" trigger and enter any gcode you wish.

--- a/docs/machines/cnc/maslow.md
+++ b/docs/machines/cnc/maslow.md
@@ -20,7 +20,13 @@ The Maslow requires calibration to correct "chain sag" (catenary effects).
 
 ### Before you Start
 
-Do a **pre-flight check**.
+!!! WARNING !!!
+
+- If this is the *first* use of your maslow, before you do anything, reset the chains !!!  Even if the sled is not exactly in the middle, to establish a baseline location, reset the chains.  Once that is complete, the sled should respond to the shuttle commands to move so then you can avoid costly disaster or erratic behavior.  As with all new equipment, please make power shutoff to the system accessible in case you must shut it off quickly.  In the makerverse, the RESET button will cut power to the motors, so keep that in mind.  After calibration, the sled will be properly positioned and allow future chain resets to occur with chain marks to reset back to the middle of the work piece.
+
+!!! WARNING !!!
+
+First, do a **pre-flight check**.
 
 Maslow frames are generally built from hand-cut, imprecise materials. Catching errors early will greatly improve the chances of an easy, successful calibration.
 

--- a/src/app/widgets/Maslow/CalibrationModal.jsx
+++ b/src/app/widgets/Maslow/CalibrationModal.jsx
@@ -624,7 +624,16 @@ class CalibrationModal extends PureComponent {
                         {curTab === 'welcome' && (
                             <div className={styles.tabFull}>
                                 <h6>{i18n._('Welcome')}</h6>
-                                If you have not tested your frame before, please run a pre-flight check.
+                                !!! WARNING !!!
+                                <br/>
+                                --  DAMAGE MAY OCCUR --
+                                <br/>
+                                If this is the first use of your system and you have not yet tested sled movement please close this window and reset your chains.
+                                <br />
+                                Please run a pre-flight check before attempting to calibrate.
+                                <br />
+                                !!! WARNING !!!
+                                <br />
                                 <br />
                                 For help with this (or any other step), see the Calibration Help at the bottom.
                                 <br />


### PR DESCRIPTION
Motivated by many users wondering why their systems have crashed upwards, or hit the floor for no reason when trying to use the Z axis for the first time, it is important that we try to prevent these user errors that can be avoided.  Added warning to calibration doc and calibration first page to remind users if this is the first use, they need to reset the chains and shuttle the sled before attempting calibration.  The only hesitation I have is I have not done this with a Mega yet, so I'm unsure if this should be Due specific information or both mega and due suggested actions.

Added example description in events doc to remind users that regardless of makerverse folder name, the system references the base makerverse folder internally as makerverse and the files are then under the events folder, so it will always look like ~/makerverse/events/scriptfilename from the event dialog window where you enter the script