### PR TITLE
new laser widget features

### DIFF
--- a/src/app/widgets/Laser/Laser.jsx
+++ b/src/app/widgets/Laser/Laser.jsx
@@ -12,7 +12,9 @@ import {
     // Grbl
     GRBL,
     // Marlin
-    MARLIN
+    MARLIN,
+    //Maslow
+    MASLOW
 } from '../../constants';
 import styles from './index.styl';
 
@@ -65,6 +67,10 @@ class Laser extends PureComponent {
       }
       if (controllerType === MARLIN) {
           const ovS = _.get(controllerState, 'ovS');
+          scale = Number(ovS) || 0;
+      }
+      if (controllerType === MASLOW) {
+          const ovS = _.get(controllerState, 'status.ov[2]', []);
           scale = Number(ovS) || 0;
       }
       return scale;
@@ -201,20 +207,29 @@ class Laser extends PureComponent {
                                       {i18n._('Test duration')}
                                   </div>
                                   <div className="table-form-col">
+                                      <div className="text-center">{test.duration}ms</div>
                                       <div
                                           className="input-group input-group-sm"
                                           style={{ width: '100%' }}
                                       >
-                                          <input
+                                          <Slider
+                                              style={{ padding: 0 }}
+                                              defaultValue={test.duration}
+                                              min={0}
+                                              max={5000}
+                                              step={100}
+                                              onChange={actions.changeLaserTestDuration}
+                                          />
+                                          {/*<input
                                               type="number"
                                               className="form-control"
                                               style={{ borderRadius: 0 }}
-                                              value={test.duration}
                                               min={0}
+                                              max={5000}
                                               step={1}
                                               onChange={actions.changeLaserTestDuration}
-                                          />
-                                          <span className="input-group-addon">{i18n._('ms')}</span>
+                                          />*/}
+                                          {/*<span className="input-group-addon">{i18n._('ms')}</span>*/}
                                       </div>
                                   </div>
                               </div>

--- a/src/app/widgets/Laser/index.jsx
+++ b/src/app/widgets/Laser/index.jsx
@@ -14,7 +14,9 @@ import {
     // Grbl
     GRBL,
     // Marlin
-    MARLIN
+    MARLIN,
+    //Maslow
+    MASLOW
 } from '../../constants';
 import styles from './index.styl';
 
@@ -78,8 +80,8 @@ class LaserWidget extends PureComponent {
                 }
             });
         },
-        changeLaserTestDuration: (event) => {
-            const value = event.target.value;
+        changeLaserTestDuration: (value) => {
+            const durationValue = Number(value) || 0;
             if (typeof value === 'string' && value.trim() === '') {
                 this.setState({
                     test: {
@@ -91,7 +93,7 @@ class LaserWidget extends PureComponent {
                 this.setState({
                     test: {
                         ...this.state.test,
-                        duration: ensurePositiveNumber(value)
+                        duration: ensurePositiveNumber(durationValue)
                     }
                 });
             }
@@ -211,7 +213,7 @@ class LaserWidget extends PureComponent {
         if (!port) {
             return false;
         }
-        if (!includes([GRBL, MARLIN], controllerType)) {
+        if (!includes([GRBL, MARLIN, MASLOW], controllerType)) {
             return false;
         }
         if (!(isNumber(test.power) && isNumber(test.duration) && isNumber(test.maxS))) {


### PR DESCRIPTION
Fixed a bug in the laser widget that wasn't enabling the test controls because it wasn't looking for MASLOW controller type. Also transitioned the test duration to a slider to prevent users from setting a high duration and potentially damaging their machine/shop.